### PR TITLE
Add networking support

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/pkg/errors v0.9.1
 	github.com/project-stacker/stacker v0.21.2
 	github.com/urfave/cli v1.22.5
+	golang.org/x/sys v0.0.0-20220227234510-4e6760a101f9
 	gopkg.in/yaml.v2 v2.4.0
 )
 
@@ -24,7 +25,8 @@ require (
 	github.com/russross/blackfriday/v2 v2.1.0 // indirect
 	github.com/sevlyar/go-daemon v0.1.6 // indirect
 	github.com/shurcooL/sanitized_anchor_name v1.0.0 // indirect
-	golang.org/x/sys v0.0.0-20220227234510-4e6760a101f9 // indirect
+	golang.org/x/crypto v0.0.0-20211117183948-ae814b36b871 // indirect
+	golang.org/x/term v0.0.0-20210927222741-03fcf44c2211 // indirect
 	gopkg.in/robfig/cron.v2 v2.0.0-20150107220207-be2e0b0deed5 // indirect
 )
 

--- a/go.sum
+++ b/go.sum
@@ -1553,6 +1553,7 @@ golang.org/x/crypto v0.0.0-20210513164829-c07d793c2f9a/go.mod h1:P+XmwS30IXTQdn5
 golang.org/x/crypto v0.0.0-20210817164053-32db794688a5/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=
 golang.org/x/crypto v0.0.0-20210921155107-089bfa567519/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=
 golang.org/x/crypto v0.0.0-20211108221036-ceb1ce70b4fa/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=
+golang.org/x/crypto v0.0.0-20211117183948-ae814b36b871 h1:/pEO3GD/ABYAjuakUS6xSEmmlyVS4kxBNkeA9tLJiTI=
 golang.org/x/crypto v0.0.0-20211117183948-ae814b36b871/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20190306152737-a1d7652674e8/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
@@ -1822,6 +1823,7 @@ golang.org/x/term v0.0.0-20201117132131-f5c789dd3221/go.mod h1:Nr5EML6q2oocZ2LXR
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/term v0.0.0-20210220032956-6a3ed077a48d/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/term v0.0.0-20210615171337-6886f2dfbf5b/go.mod h1:jbD1KX2456YbFQfuXm/mYQcufACuNUgVhRMnK/tPxf8=
+golang.org/x/term v0.0.0-20210927222741-03fcf44c2211 h1:JGgROgKl9N8DuW20oFS5gxc+lE67/N3FcwmBPMe7ArY=
 golang.org/x/term v0.0.0-20210927222741-03fcf44c2211/go.mod h1:jbD1KX2456YbFQfuXm/mYQcufACuNUgVhRMnK/tPxf8=
 golang.org/x/text v0.0.0-20170915032832-14c0d48ead0c/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.0.0-20170915090833-1cbadb444a80/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=

--- a/run.go
+++ b/run.go
@@ -109,29 +109,29 @@ func doRun(ctx *cli.Context) error {
 
 		if vmConns, ok := suite.Connections[vm.Name]; ok {
 			for nicID, networkName := range vmConns {
-				found := false
+				foundNetwork := false
 				for netidx := range suite.Networks {
 					network := suite.Networks[netidx]
 					if network.Name == networkName {
-						found = true
+						foundNetwork = true
 						break
 					}
 				}
-				if !found {
-					return fmt.Errorf("Connection specified unknown network: %s", networkName)
+				if !foundNetwork {
+					return fmt.Errorf("Connection nicID:%s specified unknown network: %s", nicID, networkName)
 				}
+				foundNic := false
 				for nidx := range vm.Nics {
-					found = false
 					vmNic := vm.Nics[nidx]
 					if nicID == vmNic.ID {
-						found = true
+						foundNic = true
 						vmNic.Network = networkName
 						log.Debugf("Connecting %s.%s -> Network=%s", vm.Name, nicID, networkName)
 						vm.Nics[nidx] = vmNic
 						break
 					}
 				}
-				if !found {
+				if !foundNic {
 					return fmt.Errorf("A connection for VM %s references undefined NIC %s", vm.Name, nicID)
 				}
 			}

--- a/run.go
+++ b/run.go
@@ -157,6 +157,9 @@ func doRun(ctx *cli.Context) error {
 					break
 				}
 			}
+			if len(nicNetwork.Name) == 0 {
+				return fmt.Errorf("Unable to find the requested network %s for nic %s", vmNic.Network, vmNic.ID)
+			}
 			if err := VM.AddNic(&vmNic, &nicNetwork); err != nil {
 				return errors.Wrapf(err, "Failed to add nic %s to network %s for vm %s", vmNic.ID, vmNic.Network, vm.Name)
 			}

--- a/vmnics.go
+++ b/vmnics.go
@@ -1,0 +1,185 @@
+package main
+
+import (
+	"fmt"
+	"math/rand"
+	"strings"
+
+	"github.com/apex/log"
+	"github.com/pkg/errors"
+)
+
+const randChars = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
+
+func randomString(length int) string {
+	if length == 0 {
+		length = 8
+	}
+	randCharLength := len(randChars)
+	b := make([]byte, length)
+	for i := range b {
+		b[i] = randChars[rand.Intn(randCharLength)]
+	}
+	return string(b)
+}
+
+const LinuxIfnameLength int = 15
+
+// generate a random Linux network interface name.
+// Allow specifying a prefix
+func randomNicIFName(prefix string) string {
+	prefixLength := len(prefix)
+	if prefixLength >= LinuxIfnameLength {
+		return randomString(LinuxIfnameLength)
+	}
+	randLength := LinuxIfnameLength - prefixLength
+	return prefix + randomString(randLength)
+}
+
+// The VMNic lifecycle: first you create one with vm.AddNic().
+// The you call Setup on it to create the tap.  Then you call
+// Args to get the qemu commandline to use it.  Finally you
+// call Cleanup to tear down the nic.
+type VMNic struct {
+	BusAddr    string
+	DeviceType string
+	HWAddr     string
+	ID         string
+	IFName     string
+	NetIFName  string
+	NetType    string
+	NetAddr    string
+	BootIndex  string
+	Ports      []PortRule
+}
+
+func (v *VM) AddNic(nicdef *NicDef, netdef *NetworkDef) error {
+	log.Debugf("AddNic: Nic: %v on Network %v", nicdef, netdef)
+	nicdef.IFName = randomNicIFName("anic")
+	nic := VMNic{
+		BusAddr:    nicdef.BusAddr,
+		DeviceType: nicdef.Device,
+		HWAddr:     nicdef.Mac,
+		ID:         nicdef.ID,
+		IFName:     nicdef.IFName,
+		NetIFName:  netdef.IFName,
+		NetType:    netdef.Type,
+		NetAddr:    netdef.Address,
+		BootIndex:  nicdef.BootIndex,
+		Ports:      nicdef.Ports,
+	}
+	log.Debugf("AddNic: Nic:%s Slot:%s -> IFName:%s Type:%s", nic.ID, nic.BusAddr, nic.IFName, nic.NetType)
+	v.opts.NICs = append(v.opts.NICs, &nic)
+	return nil
+}
+
+var macOffset int = 0
+
+func (n *VMNic) Cleanup() {
+	if n.NetType == "user" || n.NetType == "mcast" {
+		return
+	}
+	cmd := []string{"ip", "link", "set", n.IFName, "down"}
+	err := RunCommand(cmd...)
+	if err != nil {
+		log.Infof("Command %v failed: %v", cmd, err)
+	}
+	cmd = []string{"ip", "link", "set", n.IFName, "nomaster"}
+	err = RunCommand(cmd...)
+	if err != nil {
+		log.Infof("Command %v failed: %v", cmd, err)
+	}
+	cmd = []string{"ip", "link", "del", n.IFName}
+	err = RunCommand(cmd...)
+	if err != nil {
+		log.Infof("Command %v failed: %v", cmd, err)
+	}
+}
+
+func newMacAddr() string {
+	d := 2 + macOffset
+	macOffset++
+	return fmt.Sprintf("52:54:00:a2:34:%02x", d)
+}
+
+func (n *VMNic) Setup() error {
+	log.Debugf("Setting up Nic:%s Type:%s IFName:%s", n.ID, n.NetType, n.IFName)
+	if n.NetType == "user" {
+		return nil
+	}
+	if n.NetType == "bridge" {
+		// TODO: for non-root VMs, need to set user and group on tuntap
+		cmd := []string{"ip", "tuntap", "add", n.IFName, "mode", "tap"}
+		err := RunCommand(cmd...)
+		if err != nil {
+			return errors.Wrapf(err, "Error running '%s'", cmd)
+		}
+		cmd = []string{"ip", "link", "set", n.IFName, "up"}
+		err = RunCommand(cmd...)
+		if err != nil {
+			return errors.Wrapf(err, "Error running '%s'", cmd)
+		}
+		cmd = []string{"ip", "link", "set", n.IFName, "master", n.NetIFName}
+		err = RunCommand(cmd...)
+		if err != nil {
+			return errors.Wrapf(err, "Error running '%s'", cmd)
+		}
+	}
+	if n.HWAddr == "" {
+		n.HWAddr = newMacAddr()
+	}
+	log.Debugf("NIC %s on %s %s has macaddr %s", n.IFName, n.NetType, n.NetIFName, n.HWAddr)
+	return nil
+}
+
+func (n *VMNic) Args() []string {
+	// -netdev tap|user,id=$Name,opts|socket,mcast=
+	netdev := []string{}
+	// -device $device,mac=$HWAaddr,addr=$Addr,netdev=$Name
+	device := []string{}
+
+	switch n.NetType {
+	case "user":
+		netdev = append(netdev, "user")
+		if n.NetAddr != "" {
+			netdev = append(netdev, "net="+n.NetAddr)
+		}
+	case "mcast":
+		netdev = append(netdev, "socket")
+		if n.NetAddr != "" {
+			netdev = append(netdev, "mcast="+n.NetAddr)
+		}
+	default:
+		netdev = append(netdev, "tap", "ifname="+n.IFName, "script=no", "downscript=no")
+	}
+	netdev = append(netdev, "id="+n.ID)
+	if len(n.Ports) > 0 {
+		for idx := range n.Ports {
+			netdev = append(netdev, "hostfwd="+n.Ports[idx].String())
+		}
+	}
+
+	if n.DeviceType == "" {
+		device = append(device, "virtio-net")
+	} else {
+		device = append(device, n.DeviceType)
+	}
+	if n.BusAddr != "" {
+		device = append(device, "addr="+n.BusAddr)
+	}
+	if n.HWAddr != "" {
+		device = append(device, "mac="+n.HWAddr)
+	}
+	device = append(device, "netdev="+n.ID)
+
+	if n.BootIndex != "" {
+		device = append(device, "bootindex="+n.BootIndex)
+	}
+
+	// use the default pcie.0 bus
+	device = append(device, "bus=pcie.0")
+
+	return []string{
+		"-device", strings.Join(device, ","),
+		"-netdev", strings.Join(netdev, ",")}
+}

--- a/vmnics.go
+++ b/vmnics.go
@@ -29,17 +29,16 @@ const LinuxIfnameLength int = 15
 // Allow specifying a prefix
 func randomNicIFName(prefix string) string {
 	prefixLength := len(prefix)
-	if prefixLength >= LinuxIfnameLength {
+	if prefixLength >= LinuxIfnameLength+1 {
 		return randomString(LinuxIfnameLength)
 	}
 	randLength := LinuxIfnameLength - prefixLength
 	return prefix + randomString(randLength)
 }
 
-// The VMNic lifecycle: first you create one with vm.AddNic().
-// The you call Setup on it to create the tap.  Then you call
-// Args to get the qemu commandline to use it.  Finally you
-// call Cleanup to tear down the nic.
+// The VMNic lifecycle: first you create one with vm.AddNic().  Then you call
+// .Setup() on it to create the device.  Then you call .Args() to get the qemu
+// commandline to use it.  Finally you call .Cleanup() to tear down the nic.
 type VMNic struct {
 	BusAddr    string
 	DeviceType string


### PR DESCRIPTION
Implement the network connections, networks and nics configuration.

Network supports three types: user, bridge and mcast

'user'   - qemu slirp networking
'bridge' - host bridge and tun/tap interfaces (requires sudo privs)
'mcast'  - qemu socket networking using multicast routing between VMs
           using the same multicast network and ports (no sudo privs
           required)