### PR TITLE
Publish built binaries as artifacts.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,6 +19,12 @@ jobs:
       - name: Make machine binaries
         run: |
           make
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          name: binaries
+          path: bin/
+          if-no-files-found: error
       - name: Release
         uses: softprops/action-gh-release@v1
         if: startsWith(github.ref, 'refs/tags/')


### PR DESCRIPTION
On all pull requests (or on main) have c-i publish the binaries as artifacts for easier download / test.