### PR TITLE
Enable socket activation for machined

### DIFF
--- a/cmd/machined/README.md
+++ b/cmd/machined/README.md
@@ -1,0 +1,25 @@
+# machined
+
+
+machined install
+- if systemd system:
+    - write machined.socket/machined.service systemd units to user path
+    $XDG_CONFIG_HOME/systemd/user/
+    - calls systemctl --user daemon-reload
+    - calls systemctl --user enable machined.socket
+    - calls systemctl --user enable machined.server
+
+# install to user systemd config path
+machined install
+
+# overwite systemd units
+machined install --force
+
+# installs to host systemd path
+machined install --host
+
+# remove installed units
+machined remove
+
+# remove installed units from host systemd path
+sudo machined remove --host

--- a/cmd/machined/cmd/install.go
+++ b/cmd/machined/cmd/install.go
@@ -1,0 +1,92 @@
+package cmd
+
+import (
+	"fmt"
+	"machine/pkg/api"
+	"os"
+	"os/exec"
+	"path/filepath"
+
+	log "github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+)
+
+// installCmd represents the install command
+var installCmd = &cobra.Command{
+	Use:   "install",
+	Short: "Install systemd --user unit files",
+	Long:  `Install systemd unit files for machined service with socket activation.`,
+	RunE:  doInstall,
+}
+
+func doInstall(cmd *cobra.Command, args []string) error {
+	hostMode, _ := cmd.Flags().GetBool("host")
+	unitPath, err := getSystemdUnitPath(hostMode)
+	if err != nil {
+		return fmt.Errorf("Failed to get Systemd Unit Path: %s", err)
+	}
+	serviceUnit := filepath.Join(unitPath, MachinedServiceUnit)
+	socketUnit := filepath.Join(unitPath, MachinedSocketUnit)
+	customService := cmd.Flag("service-template").Value.String()
+	serviceTemplate := getTemplate(customService, MachinedServiceTemplate)
+	customSocket := cmd.Flag("socket-template").Value.String()
+	socketTemplate := getTemplate(customSocket, MachinedSocketTemplate)
+
+	// check if files exist and exit asking for --force flag
+	overwrite, _ := cmd.Flags().GetBool("force")
+	if api.PathExists(serviceUnit) && api.PathExists(socketUnit) {
+		log.Infof("machined service and socket units already exist: %q, %q", serviceUnit, socketUnit)
+		if !overwrite {
+			return nil
+		}
+		log.Infof("--force specified, overwriting files")
+	}
+	log.Infof("machined missing service and/or socket unit(s), installing..")
+	if !api.PathExists(serviceUnit) {
+		if err := installTemplate(serviceTemplate, serviceUnit); err != nil {
+			return fmt.Errorf("Failed to render template to %q: %s", serviceUnit, err)
+		}
+	}
+	if !api.PathExists(socketUnit) {
+		if err := installTemplate(socketTemplate, socketUnit); err != nil {
+			return fmt.Errorf("Failed to render service to %q: %s", socketUnit, err)
+		}
+	}
+
+	runCmd := exec.Command("systemctl", "--user", "daemon-reload")
+	out, err := runCmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("Failed to 'daemon-reload' systemd --user: %s: %s", string(out), err)
+	}
+
+	runCmd = exec.Command("systemctl", "--user", "start", MachinedSocketUnit)
+	out, err = runCmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("Failed to start unit %s: %s: %s", MachinedSocketUnit, string(out), err)
+	}
+
+	log.Infof("Checking machined.socket status...")
+	runCmd = exec.Command("systemctl", "--no-pager", "--user", "status", MachinedSocketUnit)
+	runCmd.Stdout = os.Stdout
+	err = runCmd.Run()
+	if err != nil {
+		return fmt.Errorf("Failed to start unit %s: %s: %s", MachinedSocketUnit, string(out), err)
+	}
+	log.Infof("Useful systemctl commands:")
+	log.Infof("")
+	log.Infof("  systemctl --user status %s", MachinedSocketUnit)
+	log.Infof("  systemctl --user status %s", MachinedServiceUnit)
+	log.Infof("")
+	log.Infof("To run an updated machined binary, run:")
+	log.Infof("")
+	log.Infof("  systemctl --user stop %s", MachinedServiceUnit)
+	return nil
+}
+
+func init() {
+	rootCmd.AddCommand(installCmd)
+	installCmd.PersistentFlags().BoolP("host", "H", false, "install systemd units to /etc/systemd/system instead of systemd --user path")
+	installCmd.PersistentFlags().BoolP("force", "f", false, "allow overwriting existing unit files when installing")
+	installCmd.PersistentFlags().StringP("service-template", "s", "", "specify path to custom machined service template")
+	installCmd.PersistentFlags().StringP("socket-template", "S", "", "specify path to custom machined socket template")
+}

--- a/cmd/machined/cmd/remove.go
+++ b/cmd/machined/cmd/remove.go
@@ -1,0 +1,74 @@
+package cmd
+
+import (
+	"fmt"
+	"machine/pkg/api"
+	"os"
+	"os/exec"
+	"path/filepath"
+
+	log "github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+)
+
+// removeCmd represents the remove command
+var removeCmd = &cobra.Command{
+	Use:   "remove",
+	Short: "Remove systemd --user unit files",
+	Long:  `Remove systemd unit files for machined service with socket activation.`,
+	RunE:  doRemove,
+}
+
+func doRemove(cmd *cobra.Command, args []string) error {
+	hostMode, _ := cmd.Flags().GetBool("host")
+	unitPath, err := getSystemdUnitPath(hostMode)
+	if err != nil {
+		return fmt.Errorf("Failed to get Systemd Unit Path: %s", err)
+	}
+	serviceUnit := filepath.Join(unitPath, MachinedServiceUnit)
+	socketUnit := filepath.Join(unitPath, MachinedSocketUnit)
+	removed := false
+	if api.PathExists(serviceUnit) {
+		log.Infof("Removing unit %s", serviceUnit)
+		if err := os.Remove(serviceUnit); err != nil {
+			return fmt.Errorf("Failed to remove %q: %s", serviceUnit, err)
+		}
+		removed = true
+		runCmd := exec.Command("systemctl", "--user", "stop", MachinedServiceUnit)
+		out, err := runCmd.CombinedOutput()
+		if err != nil {
+			return fmt.Errorf("Failed to stop unit %s: %s: %s", MachinedServiceUnit, string(out), err)
+		}
+	}
+	if api.PathExists(socketUnit) {
+		log.Infof("Removing unit %s", socketUnit)
+		if err := os.Remove(socketUnit); err != nil {
+			return fmt.Errorf("Failed to remove %q: %s", socketUnit, err)
+		}
+		removed = true
+		log.Infof("Stopping unit %s", socketUnit)
+		runCmd := exec.Command("systemctl", "--user", "stop", MachinedSocketUnit)
+		out, err := runCmd.CombinedOutput()
+		if err != nil {
+			return fmt.Errorf("Failed to stop unit %s: %s: %s", MachinedSocketUnit, string(out), err)
+		}
+	}
+	if removed {
+		args := []string{"daemon-reload"}
+		if !hostMode {
+			args = append(args, "--user")
+		}
+		log.Infof("Reloading systemd units")
+		runCmd := exec.Command("systemctl", args...)
+		_, err := runCmd.CombinedOutput()
+		if err != nil {
+			return fmt.Errorf("Failed to reload units: %s", err)
+		}
+	}
+	return nil
+}
+
+func init() {
+	rootCmd.AddCommand(removeCmd)
+	removeCmd.PersistentFlags().BoolP("host", "H", false, "remove systemd units in /etc/systemd/system instead of systemd --user path")
+}

--- a/go.mod
+++ b/go.mod
@@ -20,6 +20,7 @@ require (
 )
 
 require (
+	github.com/coreos/go-systemd v0.0.0-20191104093116-d3cd4ed1dbcf // indirect
 	github.com/flosch/pongo2 v0.0.0-20200913210552-0d938eb266f3 // indirect
 	github.com/fsnotify/fsnotify v1.6.0 // indirect
 	github.com/gin-contrib/sse v0.1.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -53,6 +53,8 @@ github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDk
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/cncf/udpa/go v0.0.0-20200629203442-efcf912fb354/go.mod h1:WmhPx2Nbnhtbo57+VJT5O0JRkEi1Wbu0z5j0R8u5Hbk=
 github.com/cncf/udpa/go v0.0.0-20201120205902-5459f2c99403/go.mod h1:WmhPx2Nbnhtbo57+VJT5O0JRkEi1Wbu0z5j0R8u5Hbk=
+github.com/coreos/go-systemd v0.0.0-20191104093116-d3cd4ed1dbcf h1:iW4rZ826su+pqaw19uhpSCzhj44qo35pNgKFGqzDKkU=
+github.com/coreos/go-systemd v0.0.0-20191104093116-d3cd4ed1dbcf/go.mod h1:F5haX7vjVVG0kc13fIWeqUViNPyEJxv/OmvnBo0Yme4=
 github.com/cpuguy83/go-md2man/v2 v2.0.2/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/pkg/api/config.go
+++ b/pkg/api/config.go
@@ -62,9 +62,22 @@ func (c *MachineDaemonConfig) GetConfigContext() context.Context {
 	return ctx
 }
 
-// FIXME: read from ENV variables before using fallback values
+// XDG_RUNTIME_DIR
+func UserRuntimeDir() (string, error) {
+	env := "XDG_RUNTIME_DIR"
+	if v := os.Getenv(env); v != "" {
+		return v, nil
+	}
+	uid := os.Getuid()
+	return fmt.Sprintf("/run/user/%d", uid), nil
+}
+
 //  XDG_DATA_HOME
 func UserDataDir() (string, error) {
+	env := "XDG_DATA_HOME"
+	if v := os.Getenv(env); v != "" {
+		return v, nil
+	}
 	p, err := os.UserHomeDir()
 	if err != nil {
 		return "", err
@@ -72,9 +85,12 @@ func UserDataDir() (string, error) {
 	return filepath.Join(p, ".local", "share"), nil
 }
 
-// FIXME: read from ENV variables before using fallback values
 //  XDG_CONFIG_HOME
 func UserConfigDir() (string, error) {
+	env := "XDG_CONFIG_HOME"
+	if v := os.Getenv(env); v != "" {
+		return v, nil
+	}
 	p, err := os.UserHomeDir()
 	if err != nil {
 		return "", err
@@ -82,9 +98,12 @@ func UserConfigDir() (string, error) {
 	return filepath.Join(p, ".config"), nil
 }
 
-// FIXME: read from ENV variables before using fallback values
 //  XDG_STATE_HOME
 func UserStateDir() (string, error) {
+	env := "XDG_STATE_HOME"
+	if v := os.Getenv(env); v != "" {
+		return v, nil
+	}
 	p, err := os.UserHomeDir()
 	if err != nil {
 		return "", err

--- a/pkg/api/socket.go
+++ b/pkg/api/socket.go
@@ -18,10 +18,10 @@ import (
 	"path/filepath"
 )
 
-const MachineUnixSocketName = "machine.socket"
+const MachineUnixSocketName = "machined.socket"
 
 func APISocketPath() string {
-	udd, err := UserDataDir()
+	udd, err := UserRuntimeDir()
 	if err != nil {
 		return ""
 	}

--- a/systemd/machined.service.tpl
+++ b/systemd/machined.service.tpl
@@ -1,0 +1,14 @@
+[Unit]
+Description=Machined Service
+Requires=machined.socket
+After=machined.socket
+StartLimitIntervalSec=0
+
+[Service]
+Delegate=true
+Type=exec
+KillMode=process
+ExecStart={{.MachinedBinaryPath}}
+
+[Install]
+WantedBy=default.target

--- a/systemd/machined.socket.tpl
+++ b/systemd/machined.socket.tpl
@@ -1,0 +1,9 @@
+[Unit]
+Description=Machined Socket
+
+[Socket]
+ListenStream=%t/machined/machined.socket
+SocketMode=0660
+
+[Install]
+WantedBy=sockets.target


### PR DESCRIPTION
- Adjust API socket path to XDG_RUNTIME_DIR
- Enable controller to listen to either systemd socket activation or manually start up unix socket in XDG_RUNTIME_DIR
- Add machined install, remove commands for generating/removing systemd machined.{socket,server} unit files
- Add template files