### PR TITLE
machine info: handle no such machine error

### DIFF
--- a/cmd/machine/cmd/root.go
+++ b/cmd/machine/cmd/root.go
@@ -18,8 +18,8 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"math/rand"
 	"machine/pkg/api"
+	"math/rand"
 	"net"
 	"net/http"
 	"os"
@@ -130,18 +130,18 @@ func getMachines() ([]api.Machine, error) {
 	return machines, nil
 }
 
-func getMachine(machineName string) (api.Machine, error) {
+func getMachine(machineName string) (api.Machine, int, error) {
 	machine := api.Machine{}
 	getURL := api.GetAPIURL(filepath.Join("machines", machineName))
 	if len(getURL) == 0 {
-		return machine, fmt.Errorf("Failed to get API URL for 'machines/%s' endpoint", machineName)
+		return machine, http.StatusBadRequest, fmt.Errorf("Failed to get API URL for 'machines/%s' endpoint", machineName)
 	}
 	resp, _ := rootclient.R().EnableTrace().Get(getURL)
 	err := json.Unmarshal(resp.Body(), &machine)
 	if err != nil {
-		return machine, fmt.Errorf("Failed to unmarshal GET on /machines/%s", machineName)
+		return machine, resp.StatusCode(), fmt.Errorf("%d: Failed to unmarshal GET on /machines/%s", resp.StatusCode(), machineName)
 	}
-	return machine, nil
+	return machine, resp.StatusCode(), nil
 }
 
 func postMachine(newMachine api.Machine) error {

--- a/pkg/api/routes.go
+++ b/pkg/api/routes.go
@@ -53,6 +53,8 @@ func (rh *RouteHandler) GetMachine(ctx *gin.Context) {
 	machine, err := rh.c.MachineController.GetMachine(machineName)
 	if err != nil {
 		log.Errorf("Failed to get machine '%s': %s\n", machineName, err)
+		ctx.JSON(http.StatusNotFound, gin.H{"error": err.Error()})
+		return
 	}
 	ctx.IndentedJSON(http.StatusOK, machine)
 }


### PR DESCRIPTION
- Fix GET on a specific machine and return 404
- Change info cmd to a RunE so it can exit error
- Silence cobra cli from dumping usage on error