### PR TITLE
machine init: add --machine-type parameter

### DIFF
--- a/cmd/machine/cmd/run.go
+++ b/cmd/machine/cmd/run.go
@@ -37,7 +37,7 @@ func doRun(cmd *cobra.Command, args []string) {
 	editMachine := false
 
 	// FIXME: handle mismatch between name in arg and value in config file
-	if err := DoCreateMachine(machineName, machineConfig, editMachine); err != nil {
+	if err := DoCreateMachine(machineName, defaultMachineType, machineConfig, editMachine); err != nil {
 		panic(fmt.Sprintf("Failed to create machine '%s' from config '%s': %s", machineName, machineConfig, err))
 	}
 


### PR DESCRIPTION
For now, have init accept -m/--machine-type parameter to specify
a type name for pre-built machine YAML.  I've created two types:

1.0-insecure (which was the current default, where SecureBoot was off)
1.0          (this is the new default with sb enabled, no nic)

The machine-type provides default machine configuration in the absence
of config provided by user.  If you pass in config via file or stdin
that is used and the machine-type template is ignored.

Other Changes:
- Fixed bug in template, 'secureboot' -> 'secure-boot'
- Adjusted the logging messages to indicate where config is coming from,
  stdin, file, or using machine type defaults.