### PR TITLE
Attempt import of uefi-vars file if specified

### DIFF
--- a/pkg/api/qconfig.go
+++ b/pkg/api/qconfig.go
@@ -283,17 +283,14 @@ func ConfigureUEFIVars(c *qcli.Config, srcVars, runDir string, secureBoot bool) 
 	if err != nil {
 		return fmt.Errorf("failed to create a UEFI Firmware Device: %s", err)
 	}
-
 	src := uefiDev.Vars
-	if len(srcVars) > 0 && PathExists(srcVars) {
+	if len(srcVars) > 0 {
 		src = srcVars
 	}
-
 	dest := filepath.Join(runDir, qcli.UEFIVarsFileName)
-	if !PathExists(dest) {
-		if err := CopyFileBits(src, dest); err != nil {
-			return fmt.Errorf("Failed to copy UEFI Vars from '%s' to '%q': %s", src, dest, err)
-		}
+	log.Infof("Importing UEFI Vars from '%s' to '%q'", src, dest)
+	if err := CopyFileBits(src, dest); err != nil {
+		return fmt.Errorf("Failed to import UEFI Vars from '%s' to '%q': %s", src, dest, err)
 	}
 	uefiDev.Vars = dest
 	c.UEFIFirmwareDevices = []qcli.UEFIFirmwareDevice{*uefiDev}


### PR DESCRIPTION
Previously, if the specified uefi-vars file was not found, we would silently fallback to copying vars from the host. This resulted in unexpected VM behavior as the user was not informed of the use of the fallback vars file.

- Always attempt to copy a specified file
- Always overwrite the destination file in the state dir

Fixes: #12