### PR TITLE
Fix user network port rules

### DIFF
--- a/doc/examples/vm-network-ports.yaml
+++ b/doc/examples/vm-network-ports.yaml
@@ -1,0 +1,44 @@
+type: kvm
+description: example vm showing multiple host/guest port forward syntax
+ephemeral: false
+name: slick-seal
+config:
+  name: slick-seal
+  cpus: 2
+  memory: 2048
+  serial: "true"
+  nics:
+  - device: virtio-net
+    id: nic0
+    mac: 52:54:00:81:91:9a
+    network: user
+    ports:
+    - protocol: tcp
+      host:
+        address: ""
+        port: 22222
+      guest:
+        address: ""
+        port: 22
+    - protocol: tcp
+      host:
+        address: ""
+        port: 8080
+      guest:
+        address: ""
+        port: 80
+    bootindex: "1"
+  disks:
+  - file: root.img
+    format: raw
+    size: 0
+    attach: virtio
+    type: ssd
+    bootindex: "0"
+  boot: ""
+  cdrom: ""
+  uefi-vars: /tmp/uefi_nvram-efi-shell.fd
+  tpm: true
+  tpm-version: "2.0"
+  secure-boot: false
+  gui: true

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/lxc/lxd v0.0.0-20221130220346-2c77027b7a5e
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/msoap/byline v1.1.1
-	github.com/raharper/qcli v0.0.6
+	github.com/raharper/qcli v0.0.8
 	github.com/rodaine/table v1.1.0
 	github.com/sirupsen/logrus v1.9.0
 	github.com/spf13/cobra v1.6.1

--- a/go.sum
+++ b/go.sum
@@ -211,8 +211,8 @@ github.com/pkg/xattr v0.4.9/go.mod h1:di8WF84zAKk8jzR1UBTEWh9AUlIZZ7M/JNt8e9B6kt
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=
-github.com/raharper/qcli v0.0.6 h1:O542wUJ4Bn4BVxx4Gnj1psiy5KEksaNCmFcbJR21rSo=
-github.com/raharper/qcli v0.0.6/go.mod h1:2V3cMEpdXCSWz5cqXnbBFsnLM8j81PfklKKVF1aE0RE=
+github.com/raharper/qcli v0.0.8 h1:9kxYqNPUte3rjlBW6D/R3t22gZfZvb0RQPdDygB+1AA=
+github.com/raharper/qcli v0.0.8/go.mod h1:2V3cMEpdXCSWz5cqXnbBFsnLM8j81PfklKKVF1aE0RE=
 github.com/rivo/uniseg v0.4.3 h1:utMvzDsuh3suAEnhH0RdHmoPbU648o6CvXxTx4SBMOw=
 github.com/robfig/cron/v3 v3.0.1 h1:WdRxkvbJztn8LMz/QEvLN5sBU+xKpSqwwUO1Pjr4qDs=
 github.com/robfig/cron/v3 v3.0.1/go.mod h1:eQICP3HwyT7UooqI/z+Ov+PtYAWygg1TEWWzGIFLtro=

--- a/pkg/api/network.go
+++ b/pkg/api/network.go
@@ -17,8 +17,6 @@ package api
 import (
 	"fmt"
 	"math/rand"
-	"strconv"
-	"strings"
 	"time"
 )
 
@@ -57,9 +55,25 @@ type VMNic struct {
 // nics:
 //  - id: nic1
 //    ports:
-//      - "tcp:localhost:22222": "localhost:22"
-//      - 1234: 23
-//      - 8080: 80
+//    - protocol: tcp
+//		host:
+//        address: ""  // address must be an IP, not hostname
+//        port: 22222
+//		guest:
+//        address: ""
+//        port: 22
+//    - host:
+//        address: ""
+//        port: 1234
+//    - guest:
+//        address: ""
+//        port: 23
+//    - host:
+//        address: ""
+//        port: 8080
+//    - guest:
+//        address: ""
+//        port: 80
 
 // A PortRule is a single entry map where the key and value represent
 // the host and guest mapping respectively. The Host and Guest value
@@ -73,63 +87,6 @@ type PortRule struct {
 type Port struct {
 	Address string
 	Port    int
-}
-
-func (p *PortRule) UnmarshalYAML(unmarshal func(interface{}) error) error {
-	DefaultPortProtocol := "tcp"
-	DefaultPortHostAddress := ""
-	DefaultPortGuestAddress := ""
-	var ruleVal map[string]string
-	var err error
-
-	if err = unmarshal(&ruleVal); err != nil {
-		return err
-	}
-
-	for hostVal, guestVal := range ruleVal {
-		hostToks := strings.Split(hostVal, ":")
-		if len(hostToks) == 3 {
-			p.Protocol = hostToks[0]
-			p.Host.Address = hostToks[1]
-			p.Host.Port, err = strconv.Atoi(hostToks[2])
-			if err != nil {
-				return err
-			}
-		} else if len(hostToks) == 2 {
-			p.Protocol = DefaultPortProtocol
-			p.Host.Address = hostToks[0]
-			p.Host.Port, err = strconv.Atoi(hostToks[1])
-			if err != nil {
-				return err
-			}
-		} else {
-			p.Protocol = DefaultPortProtocol
-			p.Host.Address = DefaultPortHostAddress
-			p.Host.Port, err = strconv.Atoi(hostToks[0])
-			if err != nil {
-				return err
-			}
-		}
-		guestToks := strings.Split(guestVal, ":")
-		if len(guestToks) == 2 {
-			p.Guest.Address = guestToks[0]
-			p.Guest.Port, err = strconv.Atoi(guestToks[1])
-			if err != nil {
-				return err
-			}
-		} else {
-			p.Guest.Address = DefaultPortGuestAddress
-			p.Guest.Port, err = strconv.Atoi(guestToks[0])
-			if err != nil {
-				return err
-			}
-		}
-		break
-	}
-	if p.Protocol != "tcp" && p.Protocol != "udp" {
-		return fmt.Errorf("Invalid PortRule.Protocol value: %s . Must be 'tcp' or 'udp'", p.Protocol)
-	}
-	return nil
 }
 
 func (p *PortRule) String() string {

--- a/pkg/api/qconfig.go
+++ b/pkg/api/qconfig.go
@@ -260,6 +260,17 @@ func (nd NicDef) QNetDevice(qti *qcli.QemuTypeIndex) (qcli.NetDevice, error) {
 		},
 		Driver: qcli.DeviceDriver(nd.Device),
 	}
+	if len(nd.Ports) > 0 {
+		for _, portRule := range nd.Ports {
+			rule := qcli.PortRule{}
+			rule.Protocol = portRule.Protocol
+			rule.Host.Address = portRule.Host.Address
+			rule.Host.Port = portRule.Host.Port
+			rule.Guest.Address = portRule.Guest.Address
+			rule.Guest.Port = portRule.Guest.Port
+			ndev.User.HostForward = append(ndev.User.HostForward, rule)
+		}
+	}
 	if ndev.MACAddress == "" {
 		mac, err := RandomQemuMAC()
 		if err != nil {


### PR DESCRIPTION
Allow nics using qemu 'user' networking to do host/guest port forward rules.  Update qconfig to append the rules if defined in the VM definition.

Other changes:

- Bump qcli to v0.0.8 for multiple port-rule fix
- Add example config showing port mapping syntax