### PR TITLE
Add 'romfile' to nic definition

### DIFF
--- a/doc/examples/vm-network-ports.yaml
+++ b/doc/examples/vm-network-ports.yaml
@@ -12,6 +12,7 @@ config:
     id: nic0
     mac: 52:54:00:81:91:9a
     network: user
+    romfile: "/usr/share/qemu/pxe-virtio.rom"
     ports:
     - protocol: tcp
       host:
@@ -28,6 +29,11 @@ config:
         address: ""
         port: 80
     bootindex: "1"
+  - device: virtio-net
+    id: nic1
+    mac: 52:54:00:73:28:1a
+    network: user
+    romfile: "off"  # disable built-in rom per qcli.DisabledNetDeviceROMFile
   disks:
   - file: root.img
     format: raw

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/lxc/lxd v0.0.0-20221130220346-2c77027b7a5e
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/msoap/byline v1.1.1
-	github.com/raharper/qcli v0.0.8
+	github.com/raharper/qcli v0.0.9
 	github.com/rodaine/table v1.1.0
 	github.com/sirupsen/logrus v1.9.0
 	github.com/spf13/cobra v1.6.1

--- a/go.sum
+++ b/go.sum
@@ -213,6 +213,8 @@ github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZN
 github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=
 github.com/raharper/qcli v0.0.8 h1:9kxYqNPUte3rjlBW6D/R3t22gZfZvb0RQPdDygB+1AA=
 github.com/raharper/qcli v0.0.8/go.mod h1:2V3cMEpdXCSWz5cqXnbBFsnLM8j81PfklKKVF1aE0RE=
+github.com/raharper/qcli v0.0.9 h1:s11hQHgRJJX4mz/ydeMGdosLjoUTlgDK+fiXx/k5XzE=
+github.com/raharper/qcli v0.0.9/go.mod h1:2V3cMEpdXCSWz5cqXnbBFsnLM8j81PfklKKVF1aE0RE=
 github.com/rivo/uniseg v0.4.3 h1:utMvzDsuh3suAEnhH0RdHmoPbU648o6CvXxTx4SBMOw=
 github.com/robfig/cron/v3 v3.0.1 h1:WdRxkvbJztn8LMz/QEvLN5sBU+xKpSqwwUO1Pjr4qDs=
 github.com/robfig/cron/v3 v3.0.1/go.mod h1:eQICP3HwyT7UooqI/z+Ov+PtYAWygg1TEWWzGIFLtro=

--- a/pkg/api/network.go
+++ b/pkg/api/network.go
@@ -36,6 +36,7 @@ type NicDef struct {
 	Network   string     `yaml:"network",omitempty`
 	Ports     []PortRule `yaml:"ports",omitempty`
 	BootIndex string     `yaml:"bootindex,omitempty`
+	ROMFile   string     `yaml:"romfile,omitempty`
 }
 
 type VMNic struct {

--- a/pkg/api/qconfig.go
+++ b/pkg/api/qconfig.go
@@ -255,6 +255,7 @@ func (nd NicDef) QNetDevice(qti *qcli.QemuTypeIndex) (qcli.NetDevice, error) {
 		ID:         fmt.Sprintf("net%d", qti.NextNetIndex()),
 		Addr:       nd.BusAddr,
 		MACAddress: nd.Mac,
+		ROMFile:    nd.ROMFile,
 		User: qcli.NetDeviceUser{
 			IPV4: true,
 		},


### PR DESCRIPTION
QEMU nics have built-in ROM files used during early BIOS boot to enable PXE booting.  One can specify a path to a different version via the 'romfile' parameter of the a nic definition.  Optionally, the string 'off', which is defined in qcli v0.0.9 as qcli.DisabledNetDeviceROMFile will result in passing the parameter 'romfile=' making it empty, which prevents the built-in ROM loading, removing it as a boot device.

- bump qcli to v0.0.9 for romfile disable feature
- update vm-network doc with disable example