### PR TITLE
Accept bootindex=off to remove device (disk or nic) from UEFI Boot list

### DIFF
--- a/doc/examples/vm-network-ports.yaml
+++ b/doc/examples/vm-network-ports.yaml
@@ -12,7 +12,7 @@ config:
     id: nic0
     mac: 52:54:00:81:91:9a
     network: user
-    romfile: "/usr/share/qemu/pxe-virtio.rom"
+    romfile: "/usr/share/qemu/pxe-virtio.rom"  # optionally specify rom instead of built-in one
     ports:
     - protocol: tcp
       host:
@@ -28,19 +28,20 @@ config:
       guest:
         address: ""
         port: 80
-    bootindex: "1"
+    bootindex: "0"
   - device: virtio-net
     id: nic1
     mac: 52:54:00:73:28:1a
     network: user
-    romfile: "off"  # disable built-in rom per qcli.DisabledNetDeviceROMFile
+    romfile: "off"    # disable built-in rom per qcli.DisabledNetDeviceROMFile
+    bootindex: "off"  # prevents qemu from including this device in OVMF Boot list
   disks:
   - file: root.img
     format: raw
     size: 0
     attach: virtio
     type: ssd
-    bootindex: "0"
+    bootindex: "1"
   boot: ""
   cdrom: ""
   uefi-vars: /tmp/uefi_nvram-efi-shell.fd

--- a/pkg/api/qconfig.go
+++ b/pkg/api/qconfig.go
@@ -193,7 +193,7 @@ func (qd *QemuDisk) QBlockDevice(qti *qcli.QemuTypeIndex) (qcli.BlockDevice, err
 	if blk.BlockSize == 0 {
 		blk.BlockSize = 512
 	}
-	if qd.BootIndex != "" {
+	if qd.BootIndex != "" && qd.BootIndex != "off" {
 		bootindex, err := strconv.Atoi(qd.BootIndex)
 		if err != nil {
 			return blk, fmt.Errorf("Failed parsing disk %s BootIndex '%s': %s", qd.File, qd.BootIndex, err)
@@ -279,7 +279,7 @@ func (nd NicDef) QNetDevice(qti *qcli.QemuTypeIndex) (qcli.NetDevice, error) {
 		}
 		ndev.MACAddress = mac
 	}
-	if nd.BootIndex != "" {
+	if nd.BootIndex != "" && nd.BootIndex != "off" {
 		bootindex, err := strconv.Atoi(nd.BootIndex)
 		if err != nil {
 			return qcli.NetDevice{}, fmt.Errorf("Failed parsing nic %s BootIndex '%s': %s", nd.Device, nd.BootIndex, err)

--- a/pkg/api/vm.go
+++ b/pkg/api/vm.go
@@ -83,7 +83,7 @@ func (v *VMDef) adjustDiskBootIdx(qti *qcli.QemuTypeIndex) ([]string, error) {
 	// mark any configured
 	for n := range v.Disks {
 		disk := v.Disks[n]
-		if disk.BootIndex != "" {
+		if disk.BootIndex != "" && disk.BootIndex != "off" {
 			log.Infof("disk: setting configured index %s on %s", disk.BootIndex, disk.File)
 			bootindex, err := strconv.Atoi(disk.BootIndex)
 			if err != nil {
@@ -121,7 +121,7 @@ func (v *VMDef) adjustNetBootIdx(qti *qcli.QemuTypeIndex) ([]string, error) {
 	// mark any configured
 	for n := range v.Nics {
 		nic := v.Nics[n]
-		if nic.BootIndex != "" {
+		if nic.BootIndex != "" && nic.BootIndex != "off" {
 			log.Infof("nic: setting configured index %s on %s", nic.BootIndex, nic.ID)
 			bootindex, err := strconv.Atoi(nic.BootIndex)
 			if err != nil {


### PR DESCRIPTION
Omitting the bootindex parameter to QEMU prevents OVMF firmware from attempting to boot the device.  This is useful for when you need NICs but have no reason to boot from them (skip the dreaded PXE v4, v6, HTTP v4, v6 long boot timeouts. \o/