### PR TITLE
machined install should create systemd user unit directory

### DIFF
--- a/cmd/machined/cmd/install.go
+++ b/cmd/machined/cmd/install.go
@@ -25,6 +25,11 @@ func doInstall(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return fmt.Errorf("Failed to get Systemd Unit Path: %s", err)
 	}
+	if !api.PathExists(unitPath) {
+		if err := api.EnsureDir(unitPath); err != nil {
+			return fmt.Errorf("Failed to create Systemd Unit path %q: %s", unitPath, err)
+		}
+	}
 	serviceUnit := filepath.Join(unitPath, MachinedServiceUnit)
 	socketUnit := filepath.Join(unitPath, MachinedSocketUnit)
 	customService := cmd.Flag("service-template").Value.String()


### PR DESCRIPTION
On server installs (Ubuntu Server at least) the user's .config path to systemd user units may not be present.  Ensure this path exists for attempting to render the unit template file.

@ashwing123 noticed this on the arm64 box.