### PR TITLE
add machine client api pkg

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,8 +6,8 @@ all: $(BINS)
 clean:
 	rm -f -v $(BINS)
 
-bin/machine: cmd/machine/*.go cmd/machine/cmd/*.go pkg/*/*.go
-	go build -o $@ cmd/machine/*.go
+bin/machine: cmd/machine/cmd/*.go pkg/*/*.go
+	go build -o $@ cmd/machine/cmd/*.go
 
-bin/machined: cmd/machined/*.go cmd/machined/cmd/*.go pkg/*/*.go
-	go build -o $@ cmd/machined/*.go
+bin/machined: cmd/machined/cmd/*.go pkg/*/*.go
+	go build -o $@ cmd/machined/cmd/*.go

--- a/cmd/machine/cmd/console.go
+++ b/cmd/machine/cmd/console.go
@@ -12,16 +12,16 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-package cmd
+package main
 
 import (
 	"encoding/json"
 	"fmt"
-	"machine/pkg/api"
 	"os"
 	"os/exec"
 
 	log "github.com/sirupsen/logrus"
+	"github.com/project-machine/machine/pkg/api"
 	"github.com/spf13/cobra"
 )
 

--- a/cmd/machine/cmd/delete.go
+++ b/cmd/machine/cmd/delete.go
@@ -12,13 +12,13 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-package cmd
+package main
 
 import (
 	"fmt"
-	"machine/pkg/api"
 
 	"github.com/spf13/cobra"
+	"github.com/project-machine/machine/pkg/api"
 )
 
 // deleteCmd represents the list command

--- a/cmd/machine/cmd/edit.go
+++ b/cmd/machine/cmd/edit.go
@@ -12,15 +12,15 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-package cmd
+package main
 
 import (
 	"fmt"
-	"machine/pkg/api"
 	"os"
 
 	"github.com/lxc/lxd/shared"
 	"github.com/lxc/lxd/shared/termios"
+	"github.com/project-machine/machine/pkg/api"
 	"github.com/spf13/cobra"
 	"golang.org/x/sys/unix"
 	"gopkg.in/yaml.v2"

--- a/cmd/machine/cmd/gui.go
+++ b/cmd/machine/cmd/gui.go
@@ -12,12 +12,12 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-package cmd
+package main
 
 import (
-	"machine/pkg/api"
-
 	"github.com/spf13/cobra"
+
+	"github.com/project-machine/machine/pkg/api"
 )
 
 // guiCmd represents the gui command

--- a/cmd/machine/cmd/info.go
+++ b/cmd/machine/cmd/info.go
@@ -12,7 +12,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-package cmd
+package main
 
 import (
 	"fmt"

--- a/cmd/machine/cmd/init.go
+++ b/cmd/machine/cmd/init.go
@@ -11,12 +11,11 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-package cmd
+package main
 
 import (
 	"fmt"
 	"io/ioutil"
-	"machine/pkg/api"
 	"os"
 	"path/filepath"
 	"sort"
@@ -26,6 +25,7 @@ import (
 	"github.com/lxc/lxd/shared"
 	"github.com/lxc/lxd/shared/termios"
 	homedir "github.com/mitchellh/go-homedir"
+	"github.com/project-machine/machine/pkg/api"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"golang.org/x/sys/unix"

--- a/cmd/machine/cmd/list.go
+++ b/cmd/machine/cmd/list.go
@@ -12,7 +12,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-package cmd
+package main
 
 import (
 	"fmt"

--- a/cmd/machine/cmd/main.go
+++ b/cmd/machine/cmd/main.go
@@ -14,8 +14,6 @@ limitations under the License.
 */
 package main
 
-import "machine/cmd/machine/cmd"
-
 func main() {
-	cmd.Execute()
+	Execute()
 }

--- a/cmd/machine/cmd/root.go
+++ b/cmd/machine/cmd/root.go
@@ -12,13 +12,12 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-package cmd
+package main
 
 import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"machine/pkg/api"
 	"math/rand"
 	"net"
 	"net/http"
@@ -27,6 +26,7 @@ import (
 	"time"
 
 	"github.com/go-resty/resty/v2"
+	"github.com/project-machine/machine/pkg/api"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 )

--- a/cmd/machine/cmd/run.go
+++ b/cmd/machine/cmd/run.go
@@ -12,7 +12,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-package cmd
+package main
 
 import (
 	"fmt"

--- a/cmd/machine/cmd/start.go
+++ b/cmd/machine/cmd/start.go
@@ -12,12 +12,12 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-package cmd
+package main
 
 import (
 	"fmt"
-	"machine/pkg/api"
 
+	"github.com/project-machine/machine/pkg/api"
 	"github.com/spf13/cobra"
 )
 

--- a/cmd/machine/cmd/stop.go
+++ b/cmd/machine/cmd/stop.go
@@ -12,12 +12,12 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-package cmd
+package main
 
 import (
 	"fmt"
-	"machine/pkg/api"
 
+	"github.com/project-machine/machine/pkg/api"
 	"github.com/spf13/cobra"
 )
 

--- a/cmd/machined/cmd/install.go
+++ b/cmd/machined/cmd/install.go
@@ -1,12 +1,12 @@
-package cmd
+package main
 
 import (
 	"fmt"
-	"machine/pkg/api"
 	"os"
 	"os/exec"
 	"path/filepath"
 
+	"github.com/project-machine/machine/pkg/api"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )

--- a/cmd/machined/cmd/main.go
+++ b/cmd/machined/cmd/main.go
@@ -14,8 +14,6 @@ limitations under the License.
 */
 package main
 
-import "machine/cmd/machined/cmd"
-
 func main() {
-	cmd.Execute()
+	Execute()
 }

--- a/cmd/machined/cmd/remove.go
+++ b/cmd/machined/cmd/remove.go
@@ -1,12 +1,12 @@
-package cmd
+package main
 
 import (
 	"fmt"
-	"machine/pkg/api"
 	"os"
 	"os/exec"
 	"path/filepath"
 
+	"github.com/project-machine/machine/pkg/api"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )

--- a/cmd/machined/cmd/root.go
+++ b/cmd/machined/cmd/root.go
@@ -1,10 +1,9 @@
-package cmd
+package main
 
 import (
 	"context"
 	"fmt"
 	"io/ioutil"
-	"machine/pkg/api"
 	"math/rand"
 	"net/http"
 	"os"
@@ -14,6 +13,7 @@ import (
 	"text/template"
 	"time"
 
+	"github.com/project-machine/machine/pkg/api"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module machine
+module github.com/project-machine/machine
 
 go 1.18
 

--- a/pkg/client/machine.go
+++ b/pkg/client/machine.go
@@ -1,0 +1,90 @@
+package client
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"math/rand"
+	"path/filepath"
+	"time"
+	"net"
+	"net/http"
+
+	"github.com/go-resty/resty/v2"
+
+	"github.com/project-machine/machine/pkg/api"
+)
+
+var rootclient *resty.Client
+
+func init() {
+	rand.Seed(time.Now().UTC().UnixNano())
+
+	// configure the http client to point to the unix socket
+	apiSocket := api.APISocketPath()
+	if len(apiSocket) == 0 {
+		panic("Failed to get API socket path")
+	}
+
+	unixDial := func(_ context.Context, network, addr string) (net.Conn, error) {
+		raddr, err := net.ResolveUnixAddr("unix", apiSocket)
+		if err != nil {
+			return nil, err
+		}
+
+		return net.DialUnix("unix", nil, raddr)
+	}
+
+	transport := http.Transport{
+		DialContext:           unixDial,
+		DisableKeepAlives:     true,
+		ExpectContinueTimeout: time.Second * 30,
+		ResponseHeaderTimeout: time.Second * 3600,
+		TLSHandshakeTimeout:   time.Second * 5,
+	}
+
+	rootclient = resty.New()
+	rootclient.SetTransport(&transport).SetScheme("http").SetBaseURL(apiSocket)
+}
+
+func GetMachines() ([]api.Machine, error) {
+	machines := []api.Machine{}
+	listURL := api.GetAPIURL("machines")
+	if len(listURL) == 0 {
+		return machines, fmt.Errorf("Failed to get API URL for 'machines' endpoint")
+	}
+	resp, _ := rootclient.R().EnableTrace().Get(listURL)
+	err := json.Unmarshal(resp.Body(), &machines)
+	if err != nil {
+		return machines, fmt.Errorf("Failed to unmarshal GET on /machines")
+	}
+	return machines, nil
+}
+
+func GetMachine(machineName string) (api.Machine, int, error) {
+	machine := api.Machine{}
+	getURL := api.GetAPIURL(filepath.Join("machines", machineName))
+	if len(getURL) == 0 {
+		return machine, http.StatusBadRequest, fmt.Errorf("Failed to get API URL for 'machines/%s' endpoint", machineName)
+	}
+	resp, _ := rootclient.R().EnableTrace().Get(getURL)
+	err := json.Unmarshal(resp.Body(), &machine)
+	if err != nil {
+		return machine, resp.StatusCode(), fmt.Errorf("%d: Failed to unmarshal GET on /machines/%s", resp.StatusCode(), machineName)
+	}
+	return machine, resp.StatusCode(), nil
+}
+
+func PutMachine(newMachine api.Machine) error {
+	endpoint := fmt.Sprintf("machines/%s", newMachine.Name)
+	putURL := api.GetAPIURL(endpoint)
+	if len(putURL) == 0 {
+		return fmt.Errorf("Failed to get API PUT URL for 'machines' endpoint")
+	}
+	resp, err := rootclient.R().EnableTrace().SetBody(newMachine).Put(putURL)
+	if err != nil {
+		return fmt.Errorf("Failed PUT to machine '%s' endpoint: %s", newMachine.Name, err)
+	}
+	fmt.Printf("%s %s\n", resp, resp.Status())
+	return nil
+}


### PR DESCRIPTION
Add a client API to get and put a machine.  This is used by trust to edit a machine's boot source, iso and disks.